### PR TITLE
rename “Contacts” to “Contact” in profile settings

### DIFF
--- a/OpenEmail/Mac/Profile/ProfileEditor/Group Views/ContactsProfileAttributesEditorView.swift
+++ b/OpenEmail/Mac/Profile/ProfileEditor/Group Views/ContactsProfileAttributesEditorView.swift
@@ -52,7 +52,7 @@ struct ContactsProfileAttributesEditorView: View {
                 }
             }.formStyle(.grouped)
                 .background(.regularMaterial)
-                .navigationTitle("Contacts")
+                .navigationTitle("Contact")
         }
     }
 }

--- a/OpenEmail/Shared/Profile/ProfileView/Profile+Attributes.swift
+++ b/OpenEmail/Shared/Profile/ProfileView/Profile+Attributes.swift
@@ -15,7 +15,7 @@ enum ProfileAttributesGroupType: String {
         case .work: "Work"
         case .personal: "Personal"
         case .interests: "Interests"
-        case .contacts: "Contacts"
+        case .contacts: "Contact"
         case .configuration: "Configuration"
         }
     }


### PR DESCRIPTION
This is more clear since these are places you can be contacted, not related to your address book.